### PR TITLE
docs: add Product Vision and Monetize page skeleton

### DIFF
--- a/docs/ProductVision.md
+++ b/docs/ProductVision.md
@@ -1,0 +1,18 @@
+# 🧠 VenturePilot — Product Vision (2024 Rehash)
+
+VenturePilot is your AI co‑founder — a startup‑building assistant that helps aspiring founders turn raw ideas into operational businesses through a chat‑first, wizard‑guided experience.
+
+Instead of navigating 100 disconnected tools and steps, users describe their startup once. VenturePilot then guides them step‑by‑step through:
+
+1. Idea Refinement  
+2. Validation  
+3. Branding  
+4. MVP Generation  
+5. Launch Strategy  
+6. Business Formation  
+7. IP Protection  
+8. Operational Setup  
+
+Each phase builds on the last. Users can explore, iterate, and lock in decisions as they go. VenturePilot reduces startup friction to near‑zero — no technical expertise required.
+
+**Goal:** empower smart people to build meaningful software businesses without wasting months or money.

--- a/pages/monetize.js
+++ b/pages/monetize.js
@@ -1,0 +1,34 @@
+import Nav from "../components/Nav";
+
+export default function Monetize() {
+  return (
+    <>
+      <Nav />
+      <main className="max-w-4xl mx-auto px-4 py-12">
+        <h1 className="text-2xl font-bold mb-6">Monetization Options</h1>
+
+        <div className="space-y-6">
+          <section className="p-6 bg-white dark:bg-slate-800 rounded shadow">
+            <h2 className="text-lg font-semibold mb-2">Branding Pack</h2>
+            <p className="text-sm mb-4">
+              Download high‑res logos, color palette, and typography guidelines.
+            </p>
+            <button className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700">
+              Buy for $29
+            </button>
+          </section>
+
+          <section className="p-6 bg-white dark:bg-slate-800 rounded shadow">
+            <h2 className="text-lg font-semibold mb-2">Domain Purchase</h2>
+            <p className="text-sm mb-4">
+              Secure your .com via our registrar partner.
+            </p>
+            <button className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700">
+              Check Availability
+            </button>
+          </section>
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
### Added
* **docs/ProductVision.md** – 2024 product vision and eight‑phase roadmap.
* **pages/monetize.js** – initial skeleton for the monetization step (branding pack & domain purchase CTAs).

These changes keep the `branding‑phase` branch aligned with the updated product direction and prepare for the next wizard step after Branding.